### PR TITLE
Ordaz/dev

### DIFF
--- a/ethereum/contracts/Collateral.sol
+++ b/ethereum/contracts/Collateral.sol
@@ -14,7 +14,7 @@ import "./IFund.sol";
 /// @notice This is used to operate the Takaturn fund
 /// @dev v2.0 (post-deploy)
 contract Collateral is ICollateral, Ownable {
-    uint constant public version = 2;
+    uint public constant version = 2;
 
     IFund private _fundInstance;
     AggregatorV3Interface public immutable priceFeed;
@@ -96,23 +96,18 @@ contract Collateral is ICollateral, Ownable {
 
     /// @notice Called by the manager when the cons job goes off
     /// @dev consider making the duration a variable
-    function initiateFundContract()
-        external
-        onlyOwner
-        atState(States.AcceptingCollateral)
-    {
+    function initiateFundContract() external onlyOwner atState(States.AcceptingCollateral) {
         require(fundContract == address(0));
         require(counterMembers == totalParticipants);
         // If one user is under collaterized, then all are.
-        require(
-            !_isUnderCollaterized(participants[0]), "Eth prices dropped");
+        require(!_isUnderCollaterized(participants[0]), "Eth prices dropped");
 
         fundContract = ITakaturnFactory(factoryContract).createFund(
-                                        stableCoinAddress,
-                                        participants,
-                                        cycleTime,
-                                        contributionAmount,
-                                        contributionPeriod
+            stableCoinAddress,
+            participants,
+            cycleTime,
+            contributionAmount,
+            contributionPeriod
         );
 
         // TODO: check for success before initiating instance
@@ -122,11 +117,7 @@ contract Collateral is ICollateral, Ownable {
     }
 
     /// @notice Called by each member to enter the term
-    function depositCollateral()
-        external
-        payable
-        atState(States.AcceptingCollateral)
-    {
+    function depositCollateral() external payable atState(States.AcceptingCollateral) {
         require(counterMembers < totalParticipants, "Members pending");
         require(!isCollateralMember[msg.sender], "Reentry");
         require(msg.value >= fixedCollateralEth, "Eth payment too low");
@@ -170,11 +161,9 @@ contract Collateral is ICollateral, Ownable {
 
         // Determine who will be expelled and who will just pay the contribution
         // From their collateral.
-        for (uint i = 0; i < defaulters.length; i++) {
+        for (uint i; i < defaulters.length; ) {
             currentDefaulter = defaulters[i];
-            wasBeneficiary = _fundInstance.isBeneficiary(
-                currentDefaulter
-            );
+            wasBeneficiary = _fundInstance.isBeneficiary(currentDefaulter);
             currentDefaulterBank = collateralMembersBank[currentDefaulter];
 
             if (currentDefaulter == ben) continue; // Avoid expelling graced defaulter
@@ -189,21 +178,22 @@ contract Collateral is ICollateral, Ownable {
                 collateralMembersBank[currentDefaulter] = 0;
                 totalExpellants++;
 
-                emit OnCollateralLiquidated(
-                    address(currentDefaulter),
-                    currentDefaulterBank
-                );
+                emit OnCollateralLiquidated(address(currentDefaulter), currentDefaulterBank);
             } else {
                 // Subtract contribution from defaulter and add to beneficiary.
                 collateralMembersBank[currentDefaulter] -= contributionAmountWei;
                 collateralPaymentBank[ben] += contributionAmountWei;
+            }
+            unchecked {
+                ++i;
             }
         }
 
         totalParticipants = totalParticipants - totalExpellants;
 
         // Divide and Liquidate
-        for (uint i = 0; i < participants.length; i++) {
+        uint256 participantsLength = participants.length;
+        for (uint i; i < participantsLength; ) {
             currentParticipant = participants[i];
             if (
                 !_fundInstance.isBeneficiary(currentParticipant) &&
@@ -212,14 +202,20 @@ contract Collateral is ICollateral, Ownable {
                 nonBeneficiaries[nonBeneficiaryCounter] = currentParticipant;
                 nonBeneficiaryCounter++;
             }
+            unchecked {
+                ++i;
+            }
         }
 
         // Finally, divide the share equally among non-beneficiaries
         if (nonBeneficiaryCounter > 0) {
             // This case can only happen when what?
             share = share / nonBeneficiaryCounter;
-            for (uint i = 0; i < nonBeneficiaryCounter; i++) {
+            for (uint i; i < nonBeneficiaryCounter; ) {
                 collateralPaymentBank[nonBeneficiaries[i]] += share;
+                unchecked {
+                    ++i;
+                }
             }
         }
 
@@ -229,13 +225,12 @@ contract Collateral is ICollateral, Ownable {
     /// @notice Called by each member after the end of the cycle to withraw collateral
     /// @dev This follows the pull-over-push pattern.
     function withdrawCollateral() external atState(States.ReleasingCollateral) {
-        uint amount = collateralMembersBank[msg.sender] +
-            collateralPaymentBank[msg.sender];
+        uint amount = collateralMembersBank[msg.sender] + collateralPaymentBank[msg.sender];
         require(amount > 0, "Nothing to claim");
 
         collateralMembersBank[msg.sender] = 0;
         collateralPaymentBank[msg.sender] = 0;
-        (bool success,) = payable(msg.sender).call{value: amount}("");
+        (bool success, ) = payable(msg.sender).call{value: amount}("");
         require(success);
 
         emit OnCollateralWithdrawn(msg.sender, amount);
@@ -253,7 +248,7 @@ contract Collateral is ICollateral, Ownable {
         require(amount > 0, "Nothing to claim");
         collateralPaymentBank[participant] = 0;
 
-        (bool success,) = payable(participant).call{value: amount}("");
+        (bool success, ) = payable(participant).call{value: amount}("");
         require(success);
 
         emit OnReimbursementWithdrawn(participant, amount);
@@ -263,7 +258,7 @@ contract Collateral is ICollateral, Ownable {
         require(address(fundContract) == address(msg.sender), "Wrong caller");
         _setState(States.ReleasingCollateral);
     }
-        
+
     /// @notice Checks if a user has a collateral below 1.0x of total contribution amount
     /// @dev This will revert if called during ReleasingCollateral or after
     /// @param member The user to check for
@@ -273,24 +268,20 @@ contract Collateral is ICollateral, Ownable {
     }
 
     /// @notice allow the owner to empty the Collateral after 180 days
-    function emptyCollateralAfterEnd()
-        external
-        onlyOwner
-        atState(States.ReleasingCollateral)
-    {
-        require(
-            block.timestamp > (_fundInstance.fundEnd()) + 180 days,
-            "Can't empty yet"
-        );
-
-        for (uint i = 0; i < participants.length; i++) {
+    function emptyCollateralAfterEnd() external onlyOwner atState(States.ReleasingCollateral) {
+        require(block.timestamp > (_fundInstance.fundEnd()) + 180 days, "Can't empty yet");
+        uint256 participantsLength = participants.length;
+        for (uint i; i < participantsLength; ) {
             address participant = participants[i];
             collateralMembersBank[participant] = 0;
             collateralPaymentBank[participant] = 0;
+            unchecked {
+                ++i;
+            }
         }
         _setState(States.Closed);
 
-        (bool success,) = payable(msg.sender).call{value: address(this).balance}("");
+        (bool success, ) = payable(msg.sender).call{value: address(this).balance}("");
         require(success);
     }
 
@@ -312,18 +303,17 @@ contract Collateral is ICollateral, Ownable {
     }
 
     function getParticipantSummary(address participant) external view returns (uint, uint, bool) {
-        return (collateralMembersBank[participant], collateralPaymentBank[participant], isCollateralMember[participant]);
+        return (
+            collateralMembersBank[participant],
+            collateralPaymentBank[participant],
+            isCollateralMember[participant]
+        );
     }
 
     /// @notice Gets latest ETH / USD price
     /// @return uint latest price in Wei
     function getLatestPrice() public view returns (uint) {
-        (
-            ,
-            int price,
-            ,
-            ,
-        ) = priceFeed.latestRoundData(); //8 decimals
+        (, int price, , , ) = priceFeed.latestRoundData(); //8 decimals
         return uint(price * 10 ** 10); //18 decimals
     }
 

--- a/ethereum/contracts/Collateral.sol
+++ b/ethereum/contracts/Collateral.sol
@@ -170,7 +170,7 @@ contract Collateral is ICollateral, Ownable {
 
         // Determine who will be expelled and who will just pay the contribution
         // From their collateral.
-        for (uint i = 0; i < defaulters.length; i++) {
+        for (uint i; i < defaulters.length; ) {
             currentDefaulter = defaulters[i];
             wasBeneficiary = _fundInstance.isBeneficiary(
                 currentDefaulter
@@ -198,12 +198,16 @@ contract Collateral is ICollateral, Ownable {
                 collateralMembersBank[currentDefaulter] -= contributionAmountWei;
                 collateralPaymentBank[ben] += contributionAmountWei;
             }
+            unchecked {
+                ++i;
+            }
         }
 
         totalParticipants = totalParticipants - totalExpellants;
 
         // Divide and Liquidate
-        for (uint i = 0; i < participants.length; i++) {
+        uint256 participantsLength = participants.length;
+        for (uint i; i < participantsLength; ) {
             currentParticipant = participants[i];
             if (
                 !_fundInstance.isBeneficiary(currentParticipant) &&
@@ -212,14 +216,20 @@ contract Collateral is ICollateral, Ownable {
                 nonBeneficiaries[nonBeneficiaryCounter] = currentParticipant;
                 nonBeneficiaryCounter++;
             }
+            unchecked {
+                ++i;
+            }
         }
 
         // Finally, divide the share equally among non-beneficiaries
         if (nonBeneficiaryCounter > 0) {
             // This case can only happen when what?
             share = share / nonBeneficiaryCounter;
-            for (uint i = 0; i < nonBeneficiaryCounter; i++) {
+            for (uint i; i < nonBeneficiaryCounter; ) {
                 collateralPaymentBank[nonBeneficiaries[i]] += share;
+                unchecked {
+                    ++i;
+                }
             }
         }
 
@@ -283,10 +293,14 @@ contract Collateral is ICollateral, Ownable {
             "Can't empty yet"
         );
 
-        for (uint i = 0; i < participants.length; i++) {
+        uint256 participantsLength = participants.length;
+        for (uint i; i < participantsLength; ) {
             address participant = participants[i];
             collateralMembersBank[participant] = 0;
             collateralPaymentBank[participant] = 0;
+            unchecked {
+                ++i;
+            }
         }
         _setState(States.Closed);
 

--- a/ethereum/contracts/Collateral.sol
+++ b/ethereum/contracts/Collateral.sol
@@ -14,7 +14,7 @@ import "./IFund.sol";
 /// @notice This is used to operate the Takaturn fund
 /// @dev v2.0 (post-deploy)
 contract Collateral is ICollateral, Ownable {
-    uint public constant version = 2;
+    uint constant public version = 2;
 
     IFund private _fundInstance;
     AggregatorV3Interface public immutable priceFeed;
@@ -96,18 +96,23 @@ contract Collateral is ICollateral, Ownable {
 
     /// @notice Called by the manager when the cons job goes off
     /// @dev consider making the duration a variable
-    function initiateFundContract() external onlyOwner atState(States.AcceptingCollateral) {
+    function initiateFundContract()
+        external
+        onlyOwner
+        atState(States.AcceptingCollateral)
+    {
         require(fundContract == address(0));
         require(counterMembers == totalParticipants);
         // If one user is under collaterized, then all are.
-        require(!_isUnderCollaterized(participants[0]), "Eth prices dropped");
+        require(
+            !_isUnderCollaterized(participants[0]), "Eth prices dropped");
 
         fundContract = ITakaturnFactory(factoryContract).createFund(
-            stableCoinAddress,
-            participants,
-            cycleTime,
-            contributionAmount,
-            contributionPeriod
+                                        stableCoinAddress,
+                                        participants,
+                                        cycleTime,
+                                        contributionAmount,
+                                        contributionPeriod
         );
 
         // TODO: check for success before initiating instance
@@ -117,7 +122,11 @@ contract Collateral is ICollateral, Ownable {
     }
 
     /// @notice Called by each member to enter the term
-    function depositCollateral() external payable atState(States.AcceptingCollateral) {
+    function depositCollateral()
+        external
+        payable
+        atState(States.AcceptingCollateral)
+    {
         require(counterMembers < totalParticipants, "Members pending");
         require(!isCollateralMember[msg.sender], "Reentry");
         require(msg.value >= fixedCollateralEth, "Eth payment too low");
@@ -161,9 +170,11 @@ contract Collateral is ICollateral, Ownable {
 
         // Determine who will be expelled and who will just pay the contribution
         // From their collateral.
-        for (uint i; i < defaulters.length; ) {
+        for (uint i = 0; i < defaulters.length; i++) {
             currentDefaulter = defaulters[i];
-            wasBeneficiary = _fundInstance.isBeneficiary(currentDefaulter);
+            wasBeneficiary = _fundInstance.isBeneficiary(
+                currentDefaulter
+            );
             currentDefaulterBank = collateralMembersBank[currentDefaulter];
 
             if (currentDefaulter == ben) continue; // Avoid expelling graced defaulter
@@ -178,22 +189,21 @@ contract Collateral is ICollateral, Ownable {
                 collateralMembersBank[currentDefaulter] = 0;
                 totalExpellants++;
 
-                emit OnCollateralLiquidated(address(currentDefaulter), currentDefaulterBank);
+                emit OnCollateralLiquidated(
+                    address(currentDefaulter),
+                    currentDefaulterBank
+                );
             } else {
                 // Subtract contribution from defaulter and add to beneficiary.
                 collateralMembersBank[currentDefaulter] -= contributionAmountWei;
                 collateralPaymentBank[ben] += contributionAmountWei;
-            }
-            unchecked {
-                ++i;
             }
         }
 
         totalParticipants = totalParticipants - totalExpellants;
 
         // Divide and Liquidate
-        uint256 participantsLength = participants.length;
-        for (uint i; i < participantsLength; ) {
+        for (uint i = 0; i < participants.length; i++) {
             currentParticipant = participants[i];
             if (
                 !_fundInstance.isBeneficiary(currentParticipant) &&
@@ -202,20 +212,14 @@ contract Collateral is ICollateral, Ownable {
                 nonBeneficiaries[nonBeneficiaryCounter] = currentParticipant;
                 nonBeneficiaryCounter++;
             }
-            unchecked {
-                ++i;
-            }
         }
 
         // Finally, divide the share equally among non-beneficiaries
         if (nonBeneficiaryCounter > 0) {
             // This case can only happen when what?
             share = share / nonBeneficiaryCounter;
-            for (uint i; i < nonBeneficiaryCounter; ) {
+            for (uint i = 0; i < nonBeneficiaryCounter; i++) {
                 collateralPaymentBank[nonBeneficiaries[i]] += share;
-                unchecked {
-                    ++i;
-                }
             }
         }
 
@@ -225,12 +229,13 @@ contract Collateral is ICollateral, Ownable {
     /// @notice Called by each member after the end of the cycle to withraw collateral
     /// @dev This follows the pull-over-push pattern.
     function withdrawCollateral() external atState(States.ReleasingCollateral) {
-        uint amount = collateralMembersBank[msg.sender] + collateralPaymentBank[msg.sender];
+        uint amount = collateralMembersBank[msg.sender] +
+            collateralPaymentBank[msg.sender];
         require(amount > 0, "Nothing to claim");
 
         collateralMembersBank[msg.sender] = 0;
         collateralPaymentBank[msg.sender] = 0;
-        (bool success, ) = payable(msg.sender).call{value: amount}("");
+        (bool success,) = payable(msg.sender).call{value: amount}("");
         require(success);
 
         emit OnCollateralWithdrawn(msg.sender, amount);
@@ -248,7 +253,7 @@ contract Collateral is ICollateral, Ownable {
         require(amount > 0, "Nothing to claim");
         collateralPaymentBank[participant] = 0;
 
-        (bool success, ) = payable(participant).call{value: amount}("");
+        (bool success,) = payable(participant).call{value: amount}("");
         require(success);
 
         emit OnReimbursementWithdrawn(participant, amount);
@@ -258,7 +263,7 @@ contract Collateral is ICollateral, Ownable {
         require(address(fundContract) == address(msg.sender), "Wrong caller");
         _setState(States.ReleasingCollateral);
     }
-
+        
     /// @notice Checks if a user has a collateral below 1.0x of total contribution amount
     /// @dev This will revert if called during ReleasingCollateral or after
     /// @param member The user to check for
@@ -268,20 +273,24 @@ contract Collateral is ICollateral, Ownable {
     }
 
     /// @notice allow the owner to empty the Collateral after 180 days
-    function emptyCollateralAfterEnd() external onlyOwner atState(States.ReleasingCollateral) {
-        require(block.timestamp > (_fundInstance.fundEnd()) + 180 days, "Can't empty yet");
-        uint256 participantsLength = participants.length;
-        for (uint i; i < participantsLength; ) {
+    function emptyCollateralAfterEnd()
+        external
+        onlyOwner
+        atState(States.ReleasingCollateral)
+    {
+        require(
+            block.timestamp > (_fundInstance.fundEnd()) + 180 days,
+            "Can't empty yet"
+        );
+
+        for (uint i = 0; i < participants.length; i++) {
             address participant = participants[i];
             collateralMembersBank[participant] = 0;
             collateralPaymentBank[participant] = 0;
-            unchecked {
-                ++i;
-            }
         }
         _setState(States.Closed);
 
-        (bool success, ) = payable(msg.sender).call{value: address(this).balance}("");
+        (bool success,) = payable(msg.sender).call{value: address(this).balance}("");
         require(success);
     }
 
@@ -303,17 +312,18 @@ contract Collateral is ICollateral, Ownable {
     }
 
     function getParticipantSummary(address participant) external view returns (uint, uint, bool) {
-        return (
-            collateralMembersBank[participant],
-            collateralPaymentBank[participant],
-            isCollateralMember[participant]
-        );
+        return (collateralMembersBank[participant], collateralPaymentBank[participant], isCollateralMember[participant]);
     }
 
     /// @notice Gets latest ETH / USD price
     /// @return uint latest price in Wei
     function getLatestPrice() public view returns (uint) {
-        (, int price, , , ) = priceFeed.latestRoundData(); //8 decimals
+        (
+            ,
+            int price,
+            ,
+            ,
+        ) = priceFeed.latestRoundData(); //8 decimals
         return uint(price * 10 ** 10); //18 decimals
     }
 

--- a/ethereum/contracts/Collateral.sol
+++ b/ethereum/contracts/Collateral.sol
@@ -206,7 +206,7 @@ contract Collateral is ICollateral, Ownable {
         totalParticipants = totalParticipants - totalExpellants;
 
         // Divide and Liquidate
-        uint256 participantsLength = participants.length;
+        uint participantsLength = participants.length;
         for (uint i; i < participantsLength; ) {
             currentParticipant = participants[i];
             if (
@@ -293,7 +293,7 @@ contract Collateral is ICollateral, Ownable {
             "Can't empty yet"
         );
 
-        uint256 participantsLength = participants.length;
+        uint participantsLength = participants.length;
         for (uint i; i < participantsLength; ) {
             address participant = participants[i];
             collateralMembersBank[participant] = 0;

--- a/ethereum/contracts/Fund.sol
+++ b/ethereum/contracts/Fund.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-3.0        
+// SPDX-License-Identifier: GPL-3.0
 
 pragma solidity ^0.8.9;
 
@@ -33,18 +33,18 @@ contract Fund is IFund, Ownable {
     event OnTotalParticipantsUpdated(uint indexed newLength); // Emits when the total participants lengths has changed from its initial value
     event OnAutoPayToggled(address indexed participant, bool indexed enabled); // Emits when a participant succesfully toggles autopay
 
-    uint constant public version = 2; // The version of the contract
+    uint public constant version = 2; // The version of the contract
 
-    ICollateral immutable public collateral; // Instance of the collateral
-    IERC20 immutable public stableToken; // Instance of the stable token
+    ICollateral public immutable collateral; // Instance of the collateral
+    IERC20 public immutable stableToken; // Instance of the stable token
 
     States public currentState = States.InitializingFund; // Variable to keep track of the different States
 
     uint public totalAmountOfCycles; // Amount of cycles that this fund will have
     uint public totalParticipants; // Total amount of starting participants
-    uint immutable public cycleTime; // time for a single cycle in seconds, default is 30 days
-    uint immutable public contributionAmount; // amount in stable token currency, 6 decimals
-    uint immutable public contributionPeriod; // time for participants to contribute this cycle
+    uint public immutable cycleTime; // time for a single cycle in seconds, default is 30 days
+    uint public immutable contributionAmount; // amount in stable token currency, 6 decimals
+    uint public immutable contributionPeriod; // time for participants to contribute this cycle
 
     mapping(address => bool) public isParticipant; // Mapping to keep track of who's a participant or not
     mapping(address => bool) public isBeneficiary; // Mapping to keep track of who's a beneficiary or not
@@ -84,11 +84,15 @@ contract Fund is IFund, Ownable {
         stableToken = IERC20(_stableTokenAddress);
 
         transferOwnership(Ownable(_sender).owner());
-        
+
         // Set and track participants
-        for (uint i = 0; i < _participantsArray.length; i++) {
+        uint256 participantsArrayLength = _participantsArray.length;
+        for (uint i; i < participantsArrayLength; ) {
             EnumerableSet.add(_participants, _participantsArray[i]);
             isParticipant[_participantsArray[i]] = true;
+            unchecked {
+                ++i;
+            }
         }
         beneficiariesOrder = _participantsArray;
 
@@ -103,13 +107,12 @@ contract Fund is IFund, Ownable {
 
         // Starts the first cycle
         _startNewCycle();
-        
+
         // Set timestamp of deployment, which will be used to determine cycle times
         // We do this after starting the first cycle to make sure the first cycle starts smoothly
         fundStart = block.timestamp;
     }
 
-        
     /// @notice starts a new cycle manually called by the owner. Only the first cycle starts automatically upon deploy
     function startNewCycle() external onlyOwner {
         _startNewCycle();
@@ -118,8 +121,10 @@ contract Fund is IFund, Ownable {
     /// @notice Must be called at the end of the contribution period after the time has passed by the owner
     function closeFundingPeriod() external onlyOwner {
         // Current cycle minus 1 because we use the previous cycle time as start point then add contribution period
-        require(block.timestamp > cycleTime * (currentCycle - 1) + fundStart + contributionPeriod, 
-                "Still time to contribute");
+        require(
+            block.timestamp > cycleTime * (currentCycle - 1) + fundStart + contributionPeriod,
+            "Still time to contribute"
+        );
         require(currentState == States.AcceptingContributions, "Wrong state");
 
         // We attempt to make the autopayers pay their contribution right away
@@ -132,42 +137,45 @@ contract Fund is IFund, Ownable {
         // To maintain the order and to properly push defaulters to the back based on that same order
         // And we make sure that existing defaulters are ignored
         address[] memory currentParticipants = beneficiariesOrder;
-        for (uint i = 0; i < currentParticipants.length; i++) {
+        uint256 currentParticipantsLength;
+        for (uint i; i < currentParticipantsLength; ) {
             address p = currentParticipants[i];
             if (paidThisCycle[p]) {
                 // check where to restore the defaulter to, participants or beneficiaries
                 if (isBeneficiary[p]) {
                     EnumerableSet.add(_beneficiaries, p);
-                }
-                else {
+                } else {
                     EnumerableSet.add(_participants, p);
                 }
 
                 if (EnumerableSet.remove(_defaulters, p)) {
                     emit OnParticipantUndefaulted(p);
                 }
-            }
-            else if (!EnumerableSet.contains(_defaulters, p)){
+            } else if (!EnumerableSet.contains(_defaulters, p)) {
                 _defaultParticipant(p);
+            }
+            unchecked {
+                ++i;
             }
         }
 
         // Once we decided who defaulted and who paid, we can select the beneficiary for this cycle
         _selectBeneficiary();
 
-        if (!(currentCycle < totalAmountOfCycles)) { // If all cycles have passed, and the last cycle's time has passed, close the fund
+        if (!(currentCycle < totalAmountOfCycles)) {
+            // If all cycles have passed, and the last cycle's time has passed, close the fund
             _closeFund();
             return;
         }
     }
-    
+
     /// @notice Fallback function, if the internal call fails somehow and the state gets stuck, allow owner to call the function again manually
     /// @dev This shouldn't happen, but is here in case there's an edge-case we didn't take into account, can possibly be removed in the future
     function selectBeneficiary() external onlyOwner {
         require(currentState == States.ChoosingBeneficiary, "Wrong state");
         _selectBeneficiary();
     }
-    
+
     /// @notice called by the owner to close the fund for emergency reasons.
     function closeFund() external onlyOwner {
         //require (!(currentCycle < totalAmountOfCycles), "Not all cycles have happened yet");
@@ -178,7 +186,10 @@ contract Fund is IFund, Ownable {
     //         this with the assumption that beneficiaries can't claim it themselves due to losing their keys for example,
     //         and prevent the fund to be stuck in limbo
     function emptyFundAfterEnd() external onlyOwner {
-        require(currentState == States.FundClosed && block.timestamp > fundEnd + 180 days  , "Can't empty yet");
+        require(
+            currentState == States.FundClosed && block.timestamp > fundEnd + 180 days,
+            "Can't empty yet"
+        );
 
         uint balance = stableToken.balanceOf(address(this));
         if (balance > 0) {
@@ -211,15 +222,17 @@ contract Fund is IFund, Ownable {
         require(!paidThisCycle[participant], "Already paid for cycle");
         _payContribution(msg.sender, participant);
     }
-    
+
     /// @notice Called by the beneficiary to withdraw the fund
     /// @dev This follows the pull-over-push pattern.
     function withdrawFund() external {
-        require(currentState == States.FundClosed || 
-                paidThisCycle[msg.sender], "You must pay your cycle before withdrawing");
+        require(
+            currentState == States.FundClosed || paidThisCycle[msg.sender],
+            "You must pay your cycle before withdrawing"
+        );
 
         bool hasFundPool = beneficiariesPool[msg.sender] > 0;
-        (, uint collateralPool,) = collateral.getParticipantSummary(msg.sender);
+        (, uint collateralPool, ) = collateral.getParticipantSummary(msg.sender);
         bool hasCollateralPool = collateralPool > 0;
         require(hasFundPool || hasCollateralPool, "Nothing to withdraw");
 
@@ -228,12 +241,8 @@ contract Fund is IFund, Ownable {
             uint transferAmount = beneficiariesPool[msg.sender];
             uint contractBalance = stableToken.balanceOf(address(this));
             if (contractBalance < transferAmount) {
-                revert InsufficientBalance({
-                    available: contractBalance,
-                    required: transferAmount
-                });
-            }
-            else {
+                revert InsufficientBalance({available: contractBalance, required: transferAmount});
+            } else {
                 beneficiariesPool[msg.sender] = 0;
                 stableToken.transfer(msg.sender, transferAmount); // Untrusted
             }
@@ -250,11 +259,9 @@ contract Fund is IFund, Ownable {
         uint cycleEndTimestamp = cycleTime * currentCycle + fundStart;
         if (block.timestamp > cycleEndTimestamp) {
             return 0;
-        } 
-        else {
+        } else {
             return cycleEndTimestamp - block.timestamp;
         }
-
     }
 
     // @notice returns the time left to contribute for this cycle
@@ -264,11 +271,13 @@ contract Fund is IFund, Ownable {
         }
 
         // Current cycle minus 1 because we use the previous cycle time as start point then add contribution period
-        uint contributionEndTimestamp = cycleTime * (currentCycle - 1) + fundStart + contributionPeriod;
+        uint contributionEndTimestamp = cycleTime *
+            (currentCycle - 1) +
+            fundStart +
+            contributionPeriod;
         if (block.timestamp > contributionEndTimestamp) {
             return 0;
-        }
-        else {
+        } else {
             return contributionEndTimestamp - block.timestamp;
         }
     }
@@ -285,18 +294,22 @@ contract Fund is IFund, Ownable {
 
     // @notice function to get cycle information of a specific participant
     // @param participant the user to get the info from
-    function getParticipantSummary(address participant) external view returns (uint, bool, bool, bool, bool) {
-        return (beneficiariesPool[participant], 
-                isBeneficiary[participant], 
-                paidThisCycle[participant], 
-                autoPayEnabled[participant], 
-                isParticipant[participant]);
+    function getParticipantSummary(
+        address participant
+    ) external view returns (uint, bool, bool, bool, bool) {
+        return (
+            beneficiariesPool[participant],
+            isBeneficiary[participant],
+            paidThisCycle[participant],
+            autoPayEnabled[participant],
+            isParticipant[participant]
+        );
     }
 
     /// @notice updates the state according to the input and makes sure the state can't be changed if the fund is closed. Also emits an event that this happened
     /// @param newState The new state of the fund
     function _setState(States newState) internal {
-        require (currentState != States.FundClosed, "Fund closed");
+        require(currentState != States.FundClosed, "Fund closed");
         currentState = newState;
         emit OnStateChanged(newState);
     }
@@ -304,18 +317,26 @@ contract Fund is IFund, Ownable {
     /// @notice This starts the new cycle and can only be called internally. Used upon deploy
     function _startNewCycle() internal {
         // currentCycle is 0 when this is called for the first time
-        require(block.timestamp > cycleTime * currentCycle + fundStart, "Too early to start new cycle");
-        require(currentState == States.InitializingFund || 
-                currentState == States.CycleOngoing, "Wrong state");
-        
+        require(
+            block.timestamp > cycleTime * currentCycle + fundStart,
+            "Too early to start new cycle"
+        );
+        require(
+            currentState == States.InitializingFund || currentState == States.CycleOngoing,
+            "Wrong state"
+        );
+
         currentCycle++;
         uint length = beneficiariesOrder.length;
-        for (uint i = 0; i < length; i++) {
+        for (uint i; i < length; ) {
             paidThisCycle[beneficiariesOrder[i]] = false;
+            unchecked {
+                ++i;
+            }
         }
 
         _setState(States.AcceptingContributions);
-        
+
         // We attempt to make the autopayers pay their contribution right away
         _autoPay();
     }
@@ -323,13 +344,19 @@ contract Fund is IFund, Ownable {
     /// @notice function to attempt to make autopayers pay their contribution
     function _autoPay() internal {
         address[] memory autoPayers = beneficiariesOrder;
+        uint256 autoPayersLength = autoPayers.length;
         uint amount = contributionAmount;
-        for (uint i = 0; i < autoPayers.length; i++) {
-            if (autoPayEnabled[autoPayers[i]] && 
+        for (uint i; i < autoPayersLength; ) {
+            if (
+                autoPayEnabled[autoPayers[i]] &&
                 !paidThisCycle[autoPayers[i]] &&
                 amount <= stableToken.allowance(autoPayers[i], address(this)) &&
-                amount <= stableToken.balanceOf(autoPayers[i])) {
+                amount <= stableToken.balanceOf(autoPayers[i])
+            ) {
                 _payContribution(autoPayers[i], autoPayers[i]);
+            }
+            unchecked {
+                ++i;
             }
         }
     }
@@ -341,7 +368,7 @@ contract Fund is IFund, Ownable {
         // Get the amount and do the actual transfer
         // This will only succeed if the sender approved this contract address beforehand
         uint amount = contributionAmount;
-        
+
         bool success = stableToken.transferFrom(payer, address(this), amount);
         require(success, "Contribution failed, did you approve stable token?");
 
@@ -361,7 +388,7 @@ contract Fund is IFund, Ownable {
             success = EnumerableSet.remove(_beneficiaries, defaulter);
         }
 
-        require (success, "Can't remove defaulter");
+        require(success, "Can't remove defaulter");
         EnumerableSet.add(_defaulters, defaulter);
 
         emit OnParticipantDefaulted(defaulter);
@@ -373,20 +400,24 @@ contract Fund is IFund, Ownable {
         // check if there are any participants left, else use the defaulters
         address selectedBeneficiary = address(0);
         address[] memory arrayToCheck = beneficiariesOrder;
+        uint256 arrayToCheckLength = arrayToCheck.length;
         uint beneficiaryIndex = 0;
-        for (uint i = 0; i < arrayToCheck.length; i++) { 
+        for (uint i; i < arrayToCheckLength; ) {
             address b = arrayToCheck[i];
             if (!isBeneficiary[b]) {
                 selectedBeneficiary = b;
                 beneficiaryIndex = i;
                 break;
             }
+            unchecked {
+                ++i;
+            }
         }
 
         // If the defaulter didn't pay this cycle, we move the first elligible beneficiary forward and everyone in between forward
         if (!paidThisCycle[selectedBeneficiary]) {
             // Find the index of the beneficiary to move to the end
-            for (uint i = beneficiaryIndex; i < arrayToCheck.length; i++) {
+            for (uint i = beneficiaryIndex; i < arrayToCheckLength; ) {
                 address b = arrayToCheck[i];
                 // Find the first eligible beneficiary
                 if (paidThisCycle[b]) {
@@ -401,22 +432,31 @@ contract Fund is IFund, Ownable {
                     beneficiariesOrder = newOrder;
                     break;
                 }
+                unchecked {
+                    ++i;
+                }
             }
         }
 
         // Request contribution from the collateral for those who haven't paid this cycle
         if (EnumerableSet.length(_defaulters) > 0) {
-            address[] memory expellants = collateral.requestContribution(selectedBeneficiary, 
-                                                                         EnumerableSet.values(_defaulters));
+            address[] memory expellants = collateral.requestContribution(
+                selectedBeneficiary,
+                EnumerableSet.values(_defaulters)
+            );
+            uint256 expellantsLength = expellants.length;
 
-            for (uint i = 0; i < expellants.length; i++) {
+            for (uint i; i < expellantsLength; ) {
                 if (expellants[i] == address(0)) {
                     continue;
                 }
                 _expelDefaulter(expellants[i]);
+                unchecked {
+                    ++i;
+                }
             }
         }
-        
+
         // Remove participant from participants set..
         if (EnumerableSet.remove(_participants, selectedBeneficiary)) {
             // ..Then add them to the benificiaries set
@@ -429,16 +469,20 @@ contract Fund is IFund, Ownable {
         // Get the amount of participants that paid this cycle, and add that amount to the beneficiary's pool
         uint paidCount = 0;
         address[] memory allParticipants = beneficiariesOrder; // Use beneficiariesOrder here because it contains all active participants in a single array
-        for (uint i = 0; i < allParticipants.length; i++) {
+        uint256 allParticipantsLength = allParticipants.length;
+        for (uint i; i < allParticipantsLength; ) {
             if (paidThisCycle[allParticipants[i]]) {
                 paidCount++;
             }
+            unchecked {
+                ++i;
+            }
         }
- 
+
         // Award the beneficiary with the pool and update the lastBeneficiary
         beneficiariesPool[selectedBeneficiary] = contributionAmount * paidCount;
         lastBeneficiary = selectedBeneficiary;
-        
+
         emit OnBeneficiarySelected(selectedBeneficiary);
         _setState(States.CycleOngoing);
     }
@@ -447,13 +491,17 @@ contract Fund is IFund, Ownable {
     /// @param _beneficiary The defaulter that could have been beneficiary
     function _removeBeneficiaryFromOrder(address _beneficiary) internal {
         address[] memory arrayToCheck = beneficiariesOrder;
+        uint256 arrayToCheckLength = arrayToCheck.length;
         address[] memory newArray = new address[](arrayToCheck.length - 1);
         uint j = 0;
-        for (uint i = 0; i < arrayToCheck.length; i++) {
+        for (uint i; i < arrayToCheckLength; ) {
             address b = arrayToCheck[i];
             if (b != _beneficiary) {
                 newArray[j] = b;
                 j++;
+            }
+            unchecked {
+                ++i;
             }
         }
 
@@ -464,9 +512,12 @@ contract Fund is IFund, Ownable {
     /// @param expellant The address of the defaulter that will be expelled
     function _expelDefaulter(address expellant) internal {
         //require(msg.sender == address(collateral), "Caller is not collateral");
-        require (isParticipant[expellant] && EnumerableSet.remove(_defaulters, expellant), "Expellant not found");
-  
-          // Expellants should only be in the defauters set so no need to touch the other sets
+        require(
+            isParticipant[expellant] && EnumerableSet.remove(_defaulters, expellant),
+            "Expellant not found"
+        );
+
+        // Expellants should only be in the defauters set so no need to touch the other sets
         //require(EnumerableSet.remove(_defaulters, expellant), "Expellant not found");
 
         // Remove expellant from beneficiaries order
@@ -486,10 +537,10 @@ contract Fund is IFund, Ownable {
         uint newLength = totalParticipants - 1;
         totalParticipants = newLength;
         expelledParticipants++;
-        
+
         emit OnTotalParticipantsUpdated(newLength);
     }
-    
+
     /// @notice Internal function for close fund which is used by _startNewCycle & _chooseBeneficiary to cover some edge-cases
     function _closeFund() internal {
         fundEnd = block.timestamp;

--- a/ethereum/contracts/Fund.sol
+++ b/ethereum/contracts/Fund.sol
@@ -86,7 +86,7 @@ contract Fund is IFund, Ownable {
         transferOwnership(Ownable(_sender).owner());
         
         // Set and track participants
-        uint256 _participantsArrayLength = _participantsArray.length;
+        uint _participantsArrayLength = _participantsArray.length;
         for (uint i; i < _participantsArrayLength; ) {
             EnumerableSet.add(_participants, _participantsArray[i]);
             isParticipant[_participantsArray[i]] = true;
@@ -136,7 +136,7 @@ contract Fund is IFund, Ownable {
         // To maintain the order and to properly push defaulters to the back based on that same order
         // And we make sure that existing defaulters are ignored
         address[] memory currentParticipants = beneficiariesOrder;
-        uint256 currentParticipantsLength = currentParticipants.length;
+        uint currentParticipantsLength = currentParticipants.length;
         for (uint i; i < currentParticipantsLength; ) {
             address p = currentParticipants[i];
             if (paidThisCycle[p]) {
@@ -334,7 +334,7 @@ contract Fund is IFund, Ownable {
     /// @notice function to attempt to make autopayers pay their contribution
     function _autoPay() internal {
         address[] memory autoPayers = beneficiariesOrder;
-        uint256 autoPayersLength = autoPayers.length;
+        uint autoPayersLength = autoPayers.length;
         uint amount = contributionAmount;
         for (uint i; i < autoPayersLength; ) {
             if (
@@ -389,7 +389,7 @@ contract Fund is IFund, Ownable {
         // check if there are any participants left, else use the defaulters
         address selectedBeneficiary = address(0);
         address[] memory arrayToCheck = beneficiariesOrder;
-        uint256 arrayToCheckLength = arrayToCheck.length;
+        uint arrayToCheckLength = arrayToCheck.length;
         uint beneficiaryIndex = 0;
         for (uint i; i < arrayToCheckLength; ) {
             address b = arrayToCheck[i];
@@ -432,7 +432,7 @@ contract Fund is IFund, Ownable {
             address[] memory expellants = collateral.requestContribution(selectedBeneficiary, 
                                                                          EnumerableSet.values(_defaulters));
 
-            uint256 expellantsLength = expellants.length;
+            uint expellantsLength = expellants.length;
             for (uint i; i < expellantsLength; ) {
                 if (expellants[i] == address(0)) {
                     continue;
@@ -456,7 +456,7 @@ contract Fund is IFund, Ownable {
         // Get the amount of participants that paid this cycle, and add that amount to the beneficiary's pool
         uint paidCount = 0;
         address[] memory allParticipants = beneficiariesOrder; // Use beneficiariesOrder here because it contains all active participants in a single array
-        uint256 allParticipantsLength = allParticipants.length;
+        uint allParticipantsLength = allParticipants.length;
         for (uint i; i < allParticipantsLength; ) {
             if (paidThisCycle[allParticipants[i]]) {
                 paidCount++;
@@ -478,7 +478,7 @@ contract Fund is IFund, Ownable {
     /// @param _beneficiary The defaulter that could have been beneficiary
     function _removeBeneficiaryFromOrder(address _beneficiary) internal {
         address[] memory arrayToCheck = beneficiariesOrder;
-        uint256 arrayToCheckLength = arrayToCheck.length;
+        uint arrayToCheckLength = arrayToCheck.length;
         address[] memory newArray = new address[](arrayToCheck.length - 1);
         uint j = 0;
         for (uint i; i < arrayToCheckLength; ) {


### PR DESCRIPTION
Since solidity 0.8.* there are some tricks to save gas on for loops. They are proposed on this pull request and they are the followings:
+ First you can catch the array's length before the itteration. This can save up to 100  gas on storage arrays and 3 gas fo memory and calldata arrays
+ The increment can be unchecked to avoid the overflows checks built in solidity 0.8.* This would never overflow if the loop is through an array length.
+ Explicitly initialize variables with the default value wastes gas. So there is no need to initialize 0 for uint, false for bool, address(0) for address, etc.
+ The i++ create a temporary memory variable and cost more gas than ++i
```solidity
uint i = 1; 
i++; // == 1 but i == 2
//===============//
uint i = 1; 
++i; // == 2 and i == 2 too, so no need for a temporary variable
```

This way the best for loop is
```solidity
uint length = arr.length;
for (uint i; i < length;) {
// Do stuff.
    unchecked { ++i; }
}
```

PS: I closed the last one. I forked the repo days ago so I did not realize about the auto formatter